### PR TITLE
patching method that was failing on empty array in GenericFile#to_pbcore_xml

### DIFF
--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -305,7 +305,7 @@ class GenericFile < ActiveFedora::Base
                   when "H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10"
                     "H.264/MPEG-4 AVC"
                   else
-                    stream.codec_name.first.upcase
+                    stream.codec_name.first.to_s.upcase
                   end
               }
               xml.essenceTrackEncoding(:source=>"PBCore essenceTrackEncoding")


### PR DESCRIPTION
This is a bug occurring during the XML serialization in GenericFile's to_pbcore_xml method.

I discovered there are kinds of video files (MJpeg, OGG) that return streams in the GenericFile#ffprobe datastream that lack a codec_name, which returns Nil where an Array is expected.  Without an array to work on, #upcase will raise a NoMethodError.  Adding the #to_s method to the method chain prevents this.

I can't contribute a test for this, because I discovered the bug while uploading an Apple QT mov that comes with Mountain Lion.  The file (Fish.mov, found in /System/Library/Compositions) had two codec streams coming back from ffprobe, and the second one lacked a :codec_name field (it's simply marked as codec_type = 'data').  The call to #first returned nil, and that meant #upcase raised an error.
