### PR TITLE
fixed bug in metadata show page; added workaround for blacklight bug

### DIFF
--- a/README-import.md
+++ b/README-import.md
@@ -1,4 +1,0 @@
-'./script/import_metadata <file> <user_id>'
-  
-Example:
-'./script/import_metadata spec/fixtures/import/metadata/broadway_or_bust.pbcore.xml archivist1@example.com'

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ cp config/initializers/devise.rb.sample config/initializers/devise.rb
  
 You also need ffmpeg installed with some extra codecs enabled.  See the [Sufia README file](https://github.com/projecthydra/sufia/blob/master/README.md#if-you-want-to-enable-transcoding-of-video-instal-ffmpeg-version-10) for instructions.
 
+## Importing metadata
+
+```bash
+# Usage:
+./script/import_metadata <file> <user_id>
+  
+# Example:
+./script/import_metadata spec/fixtures/import/metadata/broadway_or_bust.pbcore.xml archivist1@example.com
+```
+
 ## Start workers
 ```
 QUEUE=* rake environment resque:work

--- a/app/views/imported_metadata_files/_sort_and_per_page.html.erb
+++ b/app/views/imported_metadata_files/_sort_and_per_page.html.erb
@@ -3,6 +3,10 @@
   <div class="sorting">
       <%#= label_tag(:sort, "<strong>Sort by</strong> ".html_safe) %>
       <%#= select_tag(:sort, options_for_select(sort_fields, h(params[:sort])), :class => "input-medium") %>
+      <%
+        # hack for blacklight. Rails no longer lets helpers access controller instance variables. Fixed in blacklight 4.6.
+        @response = response
+      %>
       <%= render_pagination_info response, :entry_name=>'matching file' %>
       <% unless response.response['numFound'] < 2 %>
       <%= label_tag(:per_page) do %>


### PR DESCRIPTION
fixes #97 
This turned out to be a bug in blacklight 4.6: projectblacklight/blacklight@8b8b7d06e21dbb606feb4e1efb7136c59d8507ca
However, upgrading blacklight to 4.6 would involve changing the dependencies in sufia, sufia-models and hydra which looked like a huge pain. I added a simple workaround with a comment about it.
